### PR TITLE
Add Datajoint QC class

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -193,6 +193,8 @@ def plot_AP_band_noise(probe_dirs, probes_to_run, probe_info_dicts, FIG_SAVE_DIR
         pdir = [d for d in probe_dirs if 'probe'+pid in d][0]
         datfilepath = glob_file(os.path.join(pdir, 'continuous\\Neuropix-PXI-100.0'), 'continuous.dat')
         
+        datfilepath = os.path.realpath(datfilepath)
+        
         chunk, chan_std = calculate_probe_noise(datfilepath, chunk_size= data_chunk_size, return_chunk=True)
         
         fig, ax = plt.subplots()

--- a/probeSync_qc.py
+++ b/probeSync_qc.py
@@ -46,8 +46,8 @@ def get_ephys_barcodes(probeBase):
 
     probeTTLDir = os.path.join(probeBase, r'events\\Neuropix-PXI-100.0\\TTL_1')
     
-    channel_states = np.load(os.path.join(probeTTLDir, 'channel_states.npy'))
-    event_times = np.load(os.path.join(probeTTLDir, 'event_timestamps.npy'))
+    channel_states = np.load(os.path.realpath(os.path.join(probeTTLDir, 'channel_states.npy')))
+    event_times = np.load(os.path.realpath(os.path.join(probeTTLDir, 'event_timestamps.npy')))
     
     beRising = event_times[channel_states>0]/30000.
     beFalling = event_times[channel_states<0]/30000.
@@ -216,12 +216,12 @@ def load_spike_info(spike_data_dir, p_sampleRate, shift):
     '''
     print(p_sampleRate)
     print(shift)
-    spike_clusters = np.load(os.path.join(spike_data_dir, 'spike_clusters.npy'))
-    spike_times = np.load(os.path.join(spike_data_dir, 'spike_times.npy'))
-    templates = np.load(os.path.join(spike_data_dir, 'templates.npy'))
-    spike_templates = np.load(os.path.join(spike_data_dir, 'spike_templates.npy'))
-    channel_positions = np.load(os.path.join(spike_data_dir, 'channel_positions.npy'))
-    amplitudes = np.load(os.path.join(spike_data_dir, 'amplitudes.npy'))
+    spike_clusters = np.load(os.path.realpath(os.path.join(spike_data_dir, 'spike_clusters.npy')))
+    spike_times = np.load(os.path.realpath(os.path.join(spike_data_dir, 'spike_times.npy')))
+    templates = np.load(os.path.realpath(os.path.join(spike_data_dir, 'templates.npy')))
+    spike_templates = np.load(os.path.realpath(os.path.join(spike_data_dir, 'spike_templates.npy')))
+    channel_positions = np.load(os.path.realpath(os.path.join(spike_data_dir, 'channel_positions.npy')))
+    amplitudes = np.load(os.path.realpath(os.path.join(spike_data_dir, 'amplitudes.npy')))
     unit_ids = np.unique(spike_clusters)
     
     units = {}
@@ -256,7 +256,7 @@ def getLFPData(probeBase, syncDataset, num_channels=384):
     
     probeTTLDir = os.path.join(probeBase, r'events\\Neuropix-PXI-100.0\\TTL_1')
     lfp_data_dir = os.path.join(probeBase, r'continuous\\Neuropix-PXI-100.1')
-    lfp_data_file = os.path.join(lfp_data_dir, 'continuous.dat')
+    lfp_data_file = os.path.realpath(os.path.join(lfp_data_dir, 'continuous.dat'))
     
     
     if not os.path.exists(lfp_data_file):
@@ -265,14 +265,14 @@ def getLFPData(probeBase, syncDataset, num_channels=384):
     
     lfp_data = np.memmap(lfp_data_file, dtype='int16', mode='r')    
     lfp_data_reshape = np.reshape(lfp_data, [int(lfp_data.size/num_channels), -1])
-    time_stamps = np.load(os.path.join(lfp_data_dir, 'lfp_timestamps.npy'))
+    time_stamps = np.load(os.path.realpath(os.path.join(lfp_data_dir, 'lfp_timestamps.npy')))
         
     
     bRising, bFalling = get_sync_line_data(syncDataset, channel=0)
     bs_t, bs = ecephys.extract_barcodes_from_times(bRising, bFalling)
     
-    channel_states = np.load(os.path.join(probeTTLDir, 'channel_states.npy'))
-    event_times = np.load(os.path.join(probeTTLDir, 'event_timestamps.npy'))
+    channel_states = np.load(os.path.realpath(os.path.join(probeTTLDir, 'channel_states.npy')))
+    event_times = np.load(os.path.realpath(os.path.join(probeTTLDir, 'event_timestamps.npy')))
     
     beRising = event_times[channel_states>0]/30000.
     beFalling = event_times[channel_states<0]/30000.

--- a/qc_cmd_caller.py
+++ b/qc_cmd_caller.py
@@ -92,6 +92,8 @@ if __name__ == "__main__":
 
     parser.add_argument("-proj", "--project", help='name of project for this experiment: DR1--DynamicRouting task1', default='')
     
+    parser.add_argument("-dj", "--dj_paramset_idx", help='value of `paramset_idx` used for sorting on DataJoint (int)', type=int, default=1)
+    
     args = parser.parse_args()
     args.modules_to_run = parse_command_line_list(args.modules_to_run)
 

--- a/qc_cmd_caller.py
+++ b/qc_cmd_caller.py
@@ -15,7 +15,7 @@ import argparse
 
 def call_qc(session, probes_to_run='ABCDEF', cortical_sort=True,
             destination=r"\\allen\programs\braintv\workgroups\nc-ophys\corbettb\NP_behavior_pipeline\QC",
-            modules_to_run='all', habituation=False, passive=False, project=''):
+            modules_to_run='all', habituation=False, passive=False, project='', **kwargs):
 
     session_name = os.path.basename(session)
     print('\nRunning QC for session {} \n'
@@ -40,7 +40,7 @@ def call_qc(session, probes_to_run='ABCDEF', cortical_sort=True,
 
     
     r=qc_class(session, destination, probes_to_run=probes_to_run, 
-        cortical_sort=cortical_sort, modules_to_run=modules_to_run)
+        cortical_sort=cortical_sort, modules_to_run=modules_to_run, **kwargs)
     
     if len(r.errors)>0:
         print('Error(s) encountered: {}  \n'

--- a/qc_cmd_caller.py
+++ b/qc_cmd_caller.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
 
     parser.add_argument("-proj", "--project", help='name of project for this experiment: DR1--DynamicRouting task1', default='')
     
-    parser.add_argument("-dj", "--dj_paramset_idx", help='value of `paramset_idx` used for sorting on DataJoint (int)', type=int, default=1)
+    parser.add_argument("-dj", "--dj_kilosort_paramset_idx", help='value of `paramset_idx` used for sorting on DataJoint (int)', type=int, default=1)
     
     args = parser.parse_args()
     args.modules_to_run = parse_command_line_list(args.modules_to_run)

--- a/qc_cmd_caller.py
+++ b/qc_cmd_caller.py
@@ -93,15 +93,14 @@ if __name__ == "__main__":
     parser.add_argument("-proj", "--project", help='name of project for this experiment: DR1--DynamicRouting task1', default='')
     
     args = parser.parse_args()
-    modules_to_run = parse_command_line_list(args.modules_to_run)
-    destination = args.destination
+    args.modules_to_run = parse_command_line_list(args.modules_to_run)
 
     if args.habituation:
-        if destination == r"\\allen\programs\braintv\workgroups\nc-ophys\corbettb\NP_behavior_pipeline\QC":
-            destination = r"\\allen\programs\braintv\workgroups\nc-ophys\corbettb\NP_behavior_pipeline\QC\habituation"
-        modules_to_run = 'behavior'
-
-    call_qc(args.session, args.probes, args.cortical_sort, destination, modules_to_run, args.habituation, args.passive, args.project)
+        if args.destination == r"\\allen\programs\braintv\workgroups\nc-ophys\corbettb\NP_behavior_pipeline\QC":
+            args.destination = r"\\allen\programs\braintv\workgroups\nc-ophys\corbettb\NP_behavior_pipeline\QC\habituation"
+        args.modules_to_run = 'behavior'
+        
+    call_qc(**vars(args))
         
     
     

--- a/qc_cmd_caller.py
+++ b/qc_cmd_caller.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
     parser.add_argument("session",
                     help="full path to session directory")
     
-    parser.add_argument("-p", "--probes", 
+    parser.add_argument("-p", "--probes_to_run", 
                     help= "list of probes to run (default ABCDEF)",
                     default='ABCDEF')
     

--- a/qc_cmd_caller.py
+++ b/qc_cmd_caller.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
     parser.add_argument("session",
                     help="full path to session directory")
     
-    parser.add_argument("-p", "--probes", 
+    parser.add_argument("-p", "--probes_to_run", 
                     help= "list of probes to run (default ABCDEF)",
                     default='ABCDEF')
     
@@ -92,7 +92,7 @@ if __name__ == "__main__":
 
     parser.add_argument("-proj", "--project", help='name of project for this experiment: DR1--DynamicRouting task1', default='')
     
-    parser.add_argument("-dj", "--dj_paramset_idx", help='value of `paramset_idx` used for sorting on DataJoint (int)', type=int, default=1)
+    parser.add_argument("-dj", "--dj_kilosort_paramset_idx", help='value of `paramset_idx` used for sorting on DataJoint (int)', type=int, default=1)
     
     args = parser.parse_args()
     args.modules_to_run = parse_command_line_list(args.modules_to_run)

--- a/run_qc_class.py
+++ b/run_qc_class.py
@@ -11,7 +11,7 @@ Created on Fri Jul 10 15:42:31 2020
 
 @author: svc_ccg
 """
-
+import copy
 from typing import Optional
 import numpy as np
 import os, glob, shutil
@@ -838,26 +838,26 @@ class DR1_DJ(DR1):
 
     dj_root_dir: str = r'\\allen\programs\mindscope\workgroups\dynamicrouting\datajoint\inbox'
     
-    def __init__(self, *args, dj_kilosort_paramset_idx: int = 1, **kwargs):
+    def __init__(self, session_root_dir, *args, dj_kilosort_paramset_idx: int = 1, **kwargs):
+        self.session_root_dir = session_root_dir
         self.dj_paramset_idx = dj_kilosort_paramset_idx
         self.dj_root_dir = kwargs.get('dj_root_dir', self.dj_root_dir)
+        print('Using sorted probe data from DataJoint\n')
         super().__init__(*args, **kwargs)
     
     @property
     def session_foldername(self) -> str:
         "[lims_id]_[mouse_id]_[datestring]"
-        return f"{self.paths['es_id']}_{self.paths['external_specimen_name']}_{self.paths['datestring']}"
+        return f"{self._paths['es_id']}_{self._paths['external_specimen_name']}_{self._paths['datestring']}"
     
     @property
     def session_root_dir_parent(self) -> Optional[str]:
         """Path to dir containing `session_foldername`: e.g. np-exp, which is replaced.
             Returns None if we're working with data on lims.
         """
-        if not hasattr(self.paths) or self.paths is None:
+        if self.session_foldername not in self.session_root_dir:
             return None
-        if self.session_foldername not in self.paths['EcephysPlatformFile']:
-            return None
-        return os.path.split(self.paths['EcephysPlatformFile'].split(self.session_foldername)[0])[0] # rm trailing slashes
+        return os.path.dirname(self.session_root_dir)
     
     @property
     def ks_paramset_idx_subdir(self) -> str:
@@ -869,29 +869,30 @@ class DR1_DJ(DR1):
         return os.path.join(self.dj_root_dir, self.ks_paramset_idx_subdir)    
     
     @property
-    def paths(self) -> Optional[dict]:
-        "Modified paths pointing to local DataJoint dir for sorted probe data."
-        if not hasattr(self, '_dj_paths'):
-            return None
+    def paths(self) -> dict:
+        "Modified paths pointing to local DataJoint dir for sorted probe data."            
         return self._dj_paths
 
     @paths.setter
-    def paths(self, value: dict):
-        if value is None:
-            return
-        for probe_letter in value['data_probes']:
-            for k, v in value.items():
-                if f'probe{probe_letter}' in k or all(s in k for s in ['probe', f'_{probe_letter}']):
-                    # skips the keys 'lfpA', 'lfpB', ...
-                    value[k] = self.replace_sorted_probe_paths(path=v, probe_letter=probe_letter)
-        self._dj_paths = value
-        
-    
-    def replace_sorted_probe_paths(self, path: str, probe_letter: str) -> str:
+    def paths(self, paths: dict):
+        self._paths = paths
+        self._dj_paths = self._replaced_sorted_probe_paths(paths)
+
+    def _replaced_sorted_probe_paths(self, paths: dict) -> dict:
+        "Return dict with sorted probe paths replaced"
+        paths = copy.copy(paths) # suffices as we're only modifying strings
+        for probe_letter in paths['data_probes']:
+            for k, v in paths.items():
+                if not v:
+                    continue
+                if any(f'{s}{probe_letter}' in k for s in ('probe', 'lfp')) or all(s in k for s in ('probe', f'_{probe_letter}')):
+                    paths[k] = self._replace_sorted_probe_path(path=v, probe_letter=probe_letter)
+        return paths 
+
+    def _replace_sorted_probe_path(self, path: str, probe_letter: str) -> str:
         if self.session_root_dir_parent is None:
             # TODO
-            # data is on lims - all sorted probe data is in a flat structure so we need
-            # reconstruct the subfolders with the correct probe letter
+            # data is on lims - we need to reconstruct the subfolders with the correct probe letter
             return path
         else:
             path = path.replace(self.session_root_dir_parent, self.dj_session_root_dir_parent)

--- a/run_qc_class.py
+++ b/run_qc_class.py
@@ -31,7 +31,7 @@ from task1_behavior_session import DocData
 class run_qc():
 
     def __init__(self, exp_id, save_root, modules_to_run='all', 
-                 cortical_sort=False, probes_to_run='ABCDEF', ctx_units_percentile=50):
+                 cortical_sort=False, probes_to_run='ABCDEF', ctx_units_percentile=50, **kwargs):
 
         self.modules_to_run = modules_to_run
         self.errors = []

--- a/run_qc_class.py
+++ b/run_qc_class.py
@@ -12,20 +12,25 @@ Created on Fri Jul 10 15:42:31 2020
 @author: svc_ccg
 """
 
-from typing import Optional
-import numpy as np
-import os, glob, shutil
+import copy
+import glob
 import json
+import logging
+import os
+import shutil
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+import analysis
 import behavior_analysis
+import data_getters
+import probeSync_qc as probeSync
+from get_RFs_standalone import get_RFs
+from query_lims import query_lims
 #from visual_behavior.ophys.sync import sync_dataset
 from sync_dataset import Dataset as sync_dataset
-import pandas as pd
-import analysis
-import probeSync_qc as probeSync
-import data_getters
-from get_RFs_standalone import get_RFs
-import logging 
-from query_lims import query_lims
 from task1_behavior_session import DocData
 
 
@@ -833,31 +838,32 @@ class DR1_DJ(DR1):
     Directory structure is the same as local session folders, e.g. on np-exp, so only
     the root paths need modification if we're working with paths from
     data_getters.local_data_getter.  
-    
     """
-
+    # TODO AP continuous.dat files currently aren't downloaded from DataJoint
+    
     dj_root_dir: str = r'\\allen\programs\mindscope\workgroups\dynamicrouting\datajoint\inbox'
     
     def __init__(self, *args, dj_kilosort_paramset_idx: int = 1, **kwargs):
+        self.session_root_dir = args[0]
         self.dj_paramset_idx = dj_kilosort_paramset_idx
         self.dj_root_dir = kwargs.get('dj_root_dir', self.dj_root_dir)
+        print('Using sorted probe data from DataJoint\n')
         super().__init__(*args, **kwargs)
-    
+
+
     @property
     def session_foldername(self) -> str:
         "[lims_id]_[mouse_id]_[datestring]"
-        return f"{self.paths['es_id']}_{self.paths['external_specimen_name']}_{self.paths['datestring']}"
+        return f"{self._paths['es_id']}_{self._paths['external_specimen_name']}_{self._paths['datestring']}"
     
     @property
     def session_root_dir_parent(self) -> Optional[str]:
         """Path to dir containing `session_foldername`: e.g. np-exp, which is replaced.
             Returns None if we're working with data on lims.
         """
-        if not hasattr(self.paths) or self.paths is None:
+        if self.session_foldername not in self.session_root_dir:
             return None
-        if self.session_foldername not in self.paths['EcephysPlatformFile']:
-            return None
-        return os.path.split(self.paths['EcephysPlatformFile'].split(self.session_foldername)[0])[0] # rm trailing slashes
+        return os.path.dirname(self.session_root_dir)
     
     @property
     def ks_paramset_idx_subdir(self) -> str:
@@ -869,30 +875,45 @@ class DR1_DJ(DR1):
         return os.path.join(self.dj_root_dir, self.ks_paramset_idx_subdir)    
     
     @property
-    def paths(self) -> Optional[dict]:
-        "Modified paths pointing to local DataJoint dir for sorted probe data."
-        if not hasattr(self, '_dj_paths'):
-            return None
+    def paths(self) -> dict:
+        "Modified paths pointing to local DataJoint dir for sorted probe data."            
         return self._dj_paths
 
     @paths.setter
-    def paths(self, value: dict):
-        if value is None:
-            return
-        for probe_letter in value['data_probes']:
-            for k, v in value.items():
+    def paths(self, paths: dict):
+        self._paths = paths
+        self._dj_paths = self.replaced_sorted_probe_paths(paths)
+
+    def replaced_sorted_probe_paths(self, paths: dict) -> dict:
+        "Return dict with sorted probe paths replaced"
+        paths = copy.copy(paths) # suffices as we're only modifying strings
+        for probe_letter in paths['data_probes']:
+            for k, v in paths.items():
+                if not v:
+                    continue
+                if 'lfp' in k:
+                    continue
                 if f'probe{probe_letter}' in k or all(s in k for s in ['probe', f'_{probe_letter}']):
-                    # skips the keys 'lfpA', 'lfpB', ...
-                    value[k] = self.replace_sorted_probe_paths(path=v, probe_letter=probe_letter)
-        self._dj_paths = value
-        
-    
-    def replace_sorted_probe_paths(self, path: str, probe_letter: str) -> str:
+                    paths[k] = self.replace_sorted_probe_path(path=v, probe_letter=probe_letter)
+        return paths 
+
+    def replace_sorted_probe_path(self, path: str, probe_letter: str) -> str:
         if self.session_root_dir_parent is None:
             # TODO
-            # data is on lims - all sorted probe data is in a flat structure so we need
-            # reconstruct the subfolders with the correct probe letter
+            # data is on lims - we need to reconstruct the subfolders with the correct probe letter
             return path
         else:
-            path = path.replace(self.session_root_dir_parent, self.dj_session_root_dir_parent)
-            return path
+            newpath = path.replace(self.session_root_dir_parent, self.dj_session_root_dir_parent)
+            return newpath
+
+    def replace_files_missing_from_datajoint_download(self):        
+        # TODO move this func to np_datajoint and call with cls.download()
+        
+        # DJ sorted output doesn't come with events folder. 
+        # we can get these from np-exp for data sorted locally - but in future if we're not sorting locally
+        # we'll have to get from raw data and incorporate translater from ecephys sorting pipeline for v0.6+ OEphys
+
+        for path in glob.glob(os.path.join(self.session_root_dir_parent, self.session_foldername, '*probe*_sorted/events')):
+            dest = path.replace(self.session_root_dir_parent, self.dj_session_root_dir_parent)
+            print(f'coying {path} to {dest}')
+            shutil.copytree(path, dest, dirs_exist_ok=True)

--- a/validate_local_d2_files_ccb.py
+++ b/validate_local_d2_files_ccb.py
@@ -11,6 +11,8 @@ source_volume_config = r"\\allen\programs\braintv\workgroups\nc-ophys\corbettb\N
 with open(source_volume_config, 'r') as f:
     sources = json.load(f)
 
+sources = '//allen/programs/mindscope/workgroups/np-exp'
+
 # configuring how to find paths to the sorting data
 default_sorting_directory = 'E' 
 default_probe_directory_format = r"{}_{}_sorted"
@@ -100,8 +102,7 @@ def validate_d2_files(sessionID, acq_computer_name):
     print('running validation on following probes: {}'.format(probes_to_run))
     
     for probe in probes_to_run:
-        expected_probe_base = os.path.join(acq_computer_name, 
-                                            default_sorting_directory,
+        expected_probe_base = os.path.join(network_session_directory, 
                                             default_probe_directory_format.format(sessionID, probe))
         probe_base = glob.glob(expected_probe_base)
         print(os.path.normpath(expected_probe_base))


### PR DESCRIPTION
- adds kwargs run_qc baseclass and run_qc func
- adds `DR1_DJ` class for running  DR1 qc with Datajoint-sorted probe data
- adds a cmd line arg for specifying Kilosort `paramset_idx` used on Datajoint 

Not implemented:
- using Datajoint-sorted probe data when working with session data on lims2